### PR TITLE
yaml-cpp won't build in Ubuntu without this patch

### DIFF
--- a/build-yamlcpp.sh
+++ b/build-yamlcpp.sh
@@ -27,7 +27,7 @@ if [ ! -f .yaml-cpp_patches-applied ]; then
     for f in "$TOP/patches/*-yaml-cpp*.diff"; do
         patch -u -p1 < $f
     done
-    touch .yalm-cpp_patches-applied
+    touch .yaml-cpp_patches-applied
 fi
 
 mkdir -p ../build

--- a/build-yamlcpp.sh
+++ b/build-yamlcpp.sh
@@ -25,7 +25,7 @@ cd $EPICS_PACKAGE_TOP/yaml-cpp/$VER/src
 # Apply patches
 if [ ! -f .yaml-cpp_patches-applied ]; then
     for f in "$TOP/patches/*-yaml-cpp*.diff"; do
-        patch -p0 < $f
+        patch -u -p1 < $f
     done
     touch .yalm-cpp_patches-applied
 fi

--- a/build-yamlcpp.sh
+++ b/build-yamlcpp.sh
@@ -21,6 +21,15 @@ if [ -z "$ARCH" ]; then
 fi
 
 cd $EPICS_PACKAGE_TOP/yaml-cpp/$VER/src
+
+# Apply patches
+if [ ! -f .yaml-cpp_patches-applied ]; then
+    for f in "$TOP/patches/*-yaml-cpp*.diff"; do
+        patch -p0 < $f
+    done
+    touch .yalm-cpp_patches-applied
+fi
+
 mkdir -p ../build
 
 if [[ $ARCH =~ "buildroot"* ]]; then

--- a/patches/001-yaml-cpp_add_missing_include.diff
+++ b/patches/001-yaml-cpp_add_missing_include.diff
@@ -1,0 +1,12 @@
+diff --git a/include/yaml-cpp/node/detail/iterator.h b/include/yaml-cpp/node/detail/iterator.h
+index 2c701af..0bb3f72 100644
+--- a/include/yaml-cpp/node/detail/iterator.h
++++ b/include/yaml-cpp/node/detail/iterator.h
+@@ -12,6 +12,7 @@
+ #include "yaml-cpp/node/detail/node_iterator.h"
+ #include <boost/iterator/iterator_adaptor.hpp>
+ #include <boost/utility.hpp>
++#include <boost/next_prior.hpp>
+ 
+ namespace YAML {
+ namespace detail {


### PR DESCRIPTION
Missing include header in yaml-cpp.